### PR TITLE
Bugfix/compatibility with cookie panel 1.1.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ This app can be downloaded from [our repo](http://repo.enonic.com/public/com/eno
 
 ## Configuration
 
-Just add the app to your site. The only configuration required is setting the Container ID for Google Tag Manager.
+Just add the app to your site. The only configuration required is setting the Container ID for Google Tag Manager. Optionally, a deactivating cookie can also be defined. If this cookie is present on the site with the specified value, it will prevent tags from being added. If not configured, the deactivating cookie is by default set to "com-enonic-app-google-tagmanager_disabled" with the value "true".
 
 ## Notes
 

--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ This app can be downloaded from [our repo](http://repo.enonic.com/public/com/eno
 
 ## Configuration
 
-Just add the app to your site. The only configuration required is setting the Container ID for Google Tag Manager. Optionally, a deactivating cookie can also be defined. If this cookie is present on the site with the specified value, it will prevent tags from being added. If not configured, the deactivating cookie is by default set to "com-enonic-app-google-tagmanager_disabled" with the value "true".
+Just add the app to your site. The only configuration required is setting the Container ID for Google Tag Manager. Optionally, a deactivating cookie can also be defined. If this cookie is present on the site without having a "consented" value, it will prevent tags from being added. If not configured, the deactivating cookie is by default set to "com-enonic-app-google-tagmanager_disabled".
 
 ## Notes
 

--- a/src/main/resources/site/processors/google-tagmanager.js
+++ b/src/main/resources/site/processors/google-tagmanager.js
@@ -46,7 +46,7 @@ exports.responseProcessor = (req, res) => {
         });
 
         const containerID = siteConfig['googleTagManagerContainerID'] || '';
-        const disableCookie = siteConfig['disableCookie'] ? siteConfig['disableCookie']['name'] : defaultDisable;
+        const disableCookie = siteConfig['disableCookie'] || defaultDisable;
 
 
         // Only add snippet if in live mode and containerID is set

--- a/src/main/resources/site/site.xml
+++ b/src/main/resources/site/site.xml
@@ -5,10 +5,10 @@
       <label>Container ID</label>
       <occurrences minimum="0" maximum="1" />
     </input>
-    <item-set name="disableCookies">
-      <label>Deactivating cookies</label>
-      <help-text>Add cookies that the app will look for. If they have the value added here, Google Tag Manager won't be added to the page.</help-text>
-      <occurrences maximum="0" minimum="0" />
+    <item-set name="disableCookie">
+      <label>Deactivating cookie</label>
+      <help-text>Add a cookie that the app will look for. If it has the value added here, Google Tag Manager won't be added to the page.</help-text>
+      <occurrences maximum="1" minimum="0" />
       <items>
         <input name="name" type="TextLine">
           <label>Cookie name</label>

--- a/src/main/resources/site/site.xml
+++ b/src/main/resources/site/site.xml
@@ -5,22 +5,11 @@
       <label>Container ID</label>
       <occurrences minimum="0" maximum="1" />
     </input>
-    <item-set name="disableCookie">
+    <input name="disableCookie" type="TextLine">
       <label>Deactivating cookie</label>
-      <help-text>Add a cookie that the app will look for. If it has the value added here, Google Tag Manager won't be added to the page.</help-text>
+      <help-text>Add a control cookie that the app will look for. If this cookie has not been consented to, Google Tag Manager won't be added to the page.</help-text>
       <occurrences maximum="1" minimum="0" />
-      <items>
-        <input name="name" type="TextLine">
-          <label>Cookie name</label>
-          <occurrences maximum="1" minimum="1" />
-        </input>
-        <input name="value" type="TextLine">
-          <label>Cookie value</label>
-          <occurrences maximum="1" minimum="1" />
-          <default>true</default>
-        </input>
-      </items>
-    </item-set>
+    </input>
   </form>
   <processors>
     <response-processor name="google-tagmanager" order="10" />


### PR DESCRIPTION
Make compatible with Cookie Panel app 1.1.0

Checks for cookies on server have been removed, as they are no longer stored there. Instead, checking for disable cookie and its consent is done using `window.__RUN_ON_COOKIE_CONSENT__`. 

The `site.xml` has also been changed to allow only one disable cookie, as the idea is for this to be a control cookie determining whether to add the GTM script or not. 