### PR TITLE
feature/NJFF-812: Custom url for src

### DIFF
--- a/src/main/resources/site/processors/google-tagmanager.js
+++ b/src/main/resources/site/processors/google-tagmanager.js
@@ -20,11 +20,11 @@ const getRootSiteConfig = function () {
   return {};
 }
 
-const getDefaultScript = (containerID) => {
+const getDefaultScript = (containerID, url) => {
   const snippet = `(function(w,d,s,l,i){w[l]=w[l]||[];w[l].push({'gtm.start': \
     new Date().getTime(),event:'gtm.js'});var f=d.getElementsByTagName(s)[0], \
     j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src= \
-    '//www.googletagmanager.com/gtm.js?id='+i+dl;f.parentNode.insertBefore(j,f); \
+    'https://${url}/gtm.js?id='+i+dl;f.parentNode.insertBefore(j,f); \
     })(window,document,'script','dataLayer','${containerID}');`
   return snippet;
 };
@@ -52,6 +52,7 @@ exports.responseProcessor = (req, res) => {
   if (site && site._path) {
     const appConfig = libs.portal.getSiteConfig() || {};
     const siteConfig = appConfig.inheritConfig ? getRootSiteConfig() : appConfig;
+    const url = appConfig.customUrl ? appConfig.customUrl : "www.googletagmanager.com";
     const containerID = siteConfig['googleTagManagerContainerID'] || '';
 
     // Only add snippet if in live mode and containerID is set
@@ -59,7 +60,7 @@ exports.responseProcessor = (req, res) => {
       return res;
     }
 
-    let script = getDefaultScript(containerID);
+    let script = getDefaultScript(containerID, url);
     script = getConsentRequiredScript(script, defaultDisable);
 
     const headSnippet = `<!-- Google Tag Manager --> \

--- a/src/main/resources/site/site.xml
+++ b/src/main/resources/site/site.xml
@@ -13,6 +13,11 @@
       <label>Container ID</label>
       <occurrences minimum="0" maximum="1" />
     </input>
+    <input type="TextLine" name="customUrl">
+      <label>Custom URL</label>
+      <help-text>If the URL of the script is not 'www.googletagmanager.com' you can add a custom one here. Exmaple: https://${url}/gtm.js?id=</help-text>
+      <occurrences minimum="0" maximum="1" />
+    </input>
   </form>
   <processors>
     <response-processor name="google-tagmanager" order="10" />


### PR DESCRIPTION
Added option for custom url for customers who doesnt use www.googletagmanager.com as src.

add this as custom url to test: **sst.njff.no**